### PR TITLE
Make top-level w/b folders contain only folders

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,5 +10,6 @@ jobs:
         name: Run tests
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
-            - run: npm install && npm run test:once
+            - uses: actions/checkout@v6
+            - uses: actions/setup-node@v6
+            - run: npm install && npm run test:once -- --testTimeout=10000

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,10 +1,10 @@
 import { Outlet } from 'react-router';
 import { Header } from './Header';
 import { RepertoireErrorPage } from '@/features/repertoireErrors/RepertoireErrorPage';
+import { useStoredLineIDsToTrain } from '@/hooks/useStoredLineIDsToTrain';
 import { LOCAL_STORAGE } from '@/util/localStorage';
 import { EMPTY_REPERTOIRE } from '@/util/constants';
 import type { OutletContext } from '@/types/utility';
-import { useStoredLineIDsToTrain } from '@/hooks/useStoredLineIDsToTrain';
 
 export function App() {
     const { validationError, repertoire } = LOCAL_STORAGE.repertoire.get();

--- a/src/features/repertoire/components/folders/FolderPanel.tsx
+++ b/src/features/repertoire/components/folders/FolderPanel.tsx
@@ -1,6 +1,10 @@
+import { type FormEvent, useState } from 'react';
 import { Tabs } from './Tabs';
 import { Folder } from './Folder';
+import { FolderNameForm } from './FolderNameForm';
 import { ContainsSelectedLinesBadge } from './ContainsSelectedLinesBadge';
+import { IconButton } from '@/components/util/IconButton';
+import { COLOURS, ICONS } from '@/util/constants';
 import type { StateSetter } from '@/types/utility';
 import type { Colour } from '@/types/chessboard';
 import type {
@@ -24,6 +28,18 @@ export function FolderPanel({
     currentTab,
     setCurrentTab,
 }: FolderPanelProps) {
+    const { folders } = repertoire;
+    const folderIDs = folders[currentTab].children;
+    const [isCreatingNewFolder, setIsCreatingNewFolder] = useState(false);
+
+    function createFolder(e: FormEvent) {
+        e.preventDefault();
+        const form = e.currentTarget as HTMLFormElement;
+        const input = form.elements[0] as HTMLInputElement;
+        folders.create(input.value, currentTab);
+        setIsCreatingNewFolder(false);
+    }
+
     return (
         <div className={styles.panel}>
             <Tabs currentTab={currentTab} setCurrentTab={setCurrentTab} />
@@ -40,6 +56,13 @@ export function FolderPanel({
                     with <ContainsSelectedLinesBadge />
                 </p>
 
+                <IconButton
+                    type="button"
+                    icon={ICONS.NEW_FOLDER}
+                    ariaLabel={`new ${COLOURS[currentTab]} folder`}
+                    onClick={() => setIsCreatingNewFolder(true)}
+                />
+
                 {/* https://developer.mozilla.org/en-US/docs/Web/CSS/list-style#accessibility
                 list-style: none removes list accessibility role in Safari */}
                 <ul
@@ -47,14 +70,26 @@ export function FolderPanel({
                     role="list"
                     aria-label="folders"
                 >
-                    <Folder
-                        // key prevents sharing stale isOpen state when switching tabs
-                        key={currentTab}
-                        id={currentTab}
-                        repertoire={repertoire}
-                        currentLinesFolder={currentLinesFolder}
-                        setCurrentLinesFolder={setCurrentLinesFolder}
-                    />
+                    {folderIDs.map((folderID) => (
+                        <Folder
+                            // key prevents sharing stale isOpen state when switching tabs
+                            key={folderID}
+                            id={folderID}
+                            repertoire={repertoire}
+                            currentLinesFolder={currentLinesFolder}
+                            setCurrentLinesFolder={setCurrentLinesFolder}
+                        />
+                    ))}
+
+                    {isCreatingNewFolder && (
+                        <FolderNameForm
+                            ariaLabel="new folder"
+                            handleSubmit={createFolder}
+                            submit={{ icon: ICONS.TICK, text: 'Create folder' }}
+                            cancel={{ icon: ICONS.CROSS, text: 'Cancel' }}
+                            discardForm={() => setIsCreatingNewFolder(false)}
+                        />
+                    )}
                 </ul>
             </div>
         </div>

--- a/src/features/repertoire/components/folders/FolderPanel.tsx
+++ b/src/features/repertoire/components/folders/FolderPanel.tsx
@@ -56,12 +56,26 @@ export function FolderPanel({
                     with <ContainsSelectedLinesBadge />
                 </p>
 
-                <IconButton
-                    type="button"
-                    icon={ICONS.NEW_FOLDER}
-                    ariaLabel={`new ${COLOURS[currentTab]} folder`}
-                    onClick={() => setIsCreatingNewFolder(true)}
-                />
+                <div className={styles.newTopLevelFolderButton}>
+                    <IconButton
+                        type="button"
+                        icon={ICONS.NEW_FOLDER}
+                        ariaLabel={`new top-level ${COLOURS[currentTab]} folder`}
+                        onClick={() => setIsCreatingNewFolder(true)}
+                    />
+                </div>
+
+                {isCreatingNewFolder && (
+                    <div className="listItem">
+                        <FolderNameForm
+                            ariaLabel="new folder"
+                            handleSubmit={createFolder}
+                            submit={{ icon: ICONS.TICK, text: 'Create folder' }}
+                            cancel={{ icon: ICONS.CROSS, text: 'Cancel' }}
+                            discardForm={() => setIsCreatingNewFolder(false)}
+                        />
+                    </div>
+                )}
 
                 {/* https://developer.mozilla.org/en-US/docs/Web/CSS/list-style#accessibility
                 list-style: none removes list accessibility role in Safari */}
@@ -80,16 +94,6 @@ export function FolderPanel({
                             setCurrentLinesFolder={setCurrentLinesFolder}
                         />
                     ))}
-
-                    {isCreatingNewFolder && (
-                        <FolderNameForm
-                            ariaLabel="new folder"
-                            handleSubmit={createFolder}
-                            submit={{ icon: ICONS.TICK, text: 'Create folder' }}
-                            cancel={{ icon: ICONS.CROSS, text: 'Cancel' }}
-                            discardForm={() => setIsCreatingNewFolder(false)}
-                        />
-                    )}
                 </ul>
             </div>
         </div>

--- a/src/features/repertoire/components/folders/folders.module.css
+++ b/src/features/repertoire/components/folders/folders.module.css
@@ -13,16 +13,14 @@
 
 .folders {
     padding: 6px;
+    padding-top: 12px;
     display: flex;
     flex-direction: column;
+    gap: 12px;
     background-color: var(--bg-light);
     flex: 1;
     border-bottom-left-radius: var(--border-radius);
     border-bottom-right-radius: var(--border-radius);
-
-    & > :first-child {
-        margin: 12px 4px;
-    }
 
     & > .contents {
         margin: 0;
@@ -185,6 +183,12 @@
 .newFolder {
     margin-inline-start: var(--list-item-indent);
     z-index: 1000;
+}
+
+.newTopLevelFolderButton {
+    align-self: flex-end;
+    background-color: var(--bg-mid-light);
+    border-radius: 4px;
 }
 
 .highlighted {

--- a/src/features/repertoire/tests/__snapshots__/organisationNestedFolderState.html
+++ b/src/features/repertoire/tests/__snapshots__/organisationNestedFolderState.html
@@ -95,16 +95,20 @@
               ✔
             </span>
           </p>
-          <button
-            aria-label="new white folder"
-            class="iconButton"
-            title="New white folder"
-            type="button"
+          <div
+            class="_newTopLevelFolderButton_892ead"
           >
-            <i
-              class="fa-solid fa-folder-plus"
-            />
-          </button>
+            <button
+              aria-label="new top-level white folder"
+              class="iconButton"
+              title="New top-level white folder"
+              type="button"
+            >
+              <i
+                class="fa-solid fa-folder-plus"
+              />
+            </button>
+          </div>
           <ul
             aria-label="folders"
             class="_contents_892ead _base_892ead"

--- a/src/features/repertoire/tests/__snapshots__/organisationNestedFolderState.html
+++ b/src/features/repertoire/tests/__snapshots__/organisationNestedFolderState.html
@@ -1,0 +1,337 @@
+<div>
+  <header
+    class="_header_6395c1"
+  >
+    <div
+      class="_left_6395c1"
+    >
+      Chesslines
+      <a
+        href="https://github.com/MaoShizhong/chesslines"
+        rel="noreferrer"
+        target="_black"
+      >
+        <i
+          aria-label="open github repo in new tab"
+          class="fa-brands fa-github"
+        />
+      </a>
+    </div>
+    <nav
+      class="_right_6395c1"
+    >
+      <a
+        class=""
+        data-discover="true"
+        href="/repertoire"
+      >
+        Repertoire
+      </a>
+      <a
+        class=""
+        data-discover="true"
+        href="/trainer"
+      >
+        Trainer
+      </a>
+    </nav>
+  </header>
+  <main
+    class="_main_240d92"
+  >
+    <div
+      class="_importExport_240d92"
+    >
+      <button>
+        Import repertoire
+      </button>
+      <button
+        type="button"
+      >
+        Export repertoire
+      </button>
+    </div>
+    <div
+      class="_repertoire_240d92"
+    >
+      <div
+        class="_panel_892ead"
+      >
+        <div
+          class="_tabs_892ead"
+          role="tablist"
+        >
+          <button
+            aria-label="white repertoire"
+            aria-selected="true"
+            class="_tab_892ead"
+            id="_leftTab_892ead"
+            role="tab"
+          >
+            White
+          </button>
+          <button
+            aria-label="black repertoire"
+            aria-selected="false"
+            class="_tab_892ead"
+            id="_rightTab_892ead"
+            role="tab"
+          >
+            Black
+          </button>
+        </div>
+        <div
+          aria-labelledby="_leftTab_892ead"
+          class="_folders_892ead"
+          role="tabpanel"
+        >
+          <p>
+            Folders containing lines selected for training are marked with 
+            <span
+              class="badge"
+              style="background-color: var(--bg-very-light); color: var(--text-contrast);"
+              title="Folder contains lines selected for training"
+            >
+              ✔
+            </span>
+          </p>
+          <button
+            aria-label="new white folder"
+            class="iconButton"
+            title="New white folder"
+            type="button"
+          >
+            <i
+              class="fa-solid fa-folder-plus"
+            />
+          </button>
+          <ul
+            aria-label="folders"
+            class="_contents_892ead _base_892ead"
+            role="list"
+          >
+            <li
+              aria-label="line folder closed folder"
+              class="_folder_892ead"
+              data-type="folder"
+              draggable="true"
+              id="id-68cafccd-d7b8-4f92-9153-9df59eee4f03"
+            >
+              <div
+                class="_controls_892ead"
+              >
+                <div
+                  aria-label="drag handle"
+                  class="_dragHandle_892ead"
+                  title="Drag to move folder"
+                >
+                  <i
+                    class="fa-solid fa-grip-lines-vertical"
+                  />
+                </div>
+                <div
+                  class="_heading_892ead _notBase_892ead"
+                  title="Open folder in lines panel"
+                >
+                  <button
+                    aria-label="open line folder folder in lines panel"
+                    class="_openToggle_892ead"
+                  />
+                  <h2>
+                    line folder
+                  </h2>
+                  <button
+                    aria-label="rename folder"
+                    class="iconButton"
+                    title="Rename folder"
+                    type="button"
+                  >
+                    <i
+                      class="fa-solid fa-pencil"
+                    />
+                  </button>
+                </div>
+              </div>
+            </li>
+            <li
+              aria-label="folder folder open folder"
+              class="_folder_892ead"
+              data-type="folder"
+              draggable="true"
+              id="id-68cafccd-d7b8-4f92-9153-9df59eee4f04"
+            >
+              <div
+                class="_controls_892ead"
+              >
+                <div
+                  aria-label="drag handle"
+                  class="_dragHandle_892ead"
+                  title="Drag to move folder"
+                >
+                  <i
+                    class="fa-solid fa-grip-lines-vertical"
+                  />
+                </div>
+                <div
+                  class="_heading_892ead _notBase_892ead"
+                  title="Collapse folder"
+                >
+                  <button
+                    aria-label="close folder folder folder "
+                    class="_openToggle_892ead"
+                  />
+                  <i
+                    class="fa-solid fa-caret-down"
+                  />
+                  <h2>
+                    folder folder
+                  </h2>
+                  <button
+                    aria-label="rename folder"
+                    class="iconButton"
+                    title="Rename folder"
+                    type="button"
+                  >
+                    <i
+                      class="fa-solid fa-pencil"
+                    />
+                  </button>
+                  <button
+                    aria-label="new folder"
+                    class="iconButton"
+                    title="New folder"
+                    type="button"
+                  >
+                    <i
+                      class="fa-solid fa-folder-plus"
+                    />
+                  </button>
+                </div>
+              </div>
+              <ul
+                aria-label="folders within folder folder folder"
+                class="_contents_892ead"
+                role="list"
+              >
+                <li
+                  aria-label="empty folder closed folder"
+                  class="_folder_892ead"
+                  data-type="folder"
+                  draggable="true"
+                  id="id-68cafccd-d7b8-4f92-9153-9df59eee4f05"
+                >
+                  <div
+                    class="_controls_892ead"
+                  >
+                    <div
+                      aria-label="drag handle"
+                      class="_dragHandle_892ead"
+                      title="Drag to move folder"
+                    >
+                      <i
+                        class="fa-solid fa-grip-lines-vertical"
+                      />
+                    </div>
+                    <div
+                      class="_heading_892ead _notBase_892ead"
+                      title="Open folder in lines panel"
+                    >
+                      <button
+                        aria-label="open empty folder folder in lines panel"
+                        class="_openToggle_892ead"
+                      />
+                      <h2>
+                        empty folder
+                      </h2>
+                      <button
+                        aria-label="rename folder"
+                        class="iconButton"
+                        title="Rename folder"
+                        type="button"
+                      >
+                        <i
+                          class="fa-solid fa-pencil"
+                        />
+                      </button>
+                      <button
+                        aria-label="new folder"
+                        class="iconButton"
+                        title="New folder"
+                        type="button"
+                      >
+                        <i
+                          class="fa-solid fa-folder-plus"
+                        />
+                      </button>
+                      <button
+                        aria-label="delete folder"
+                        class="iconButton"
+                        title="Delete folder"
+                        type="button"
+                      >
+                        <i
+                          class="fa-solid fa-trash"
+                        />
+                      </button>
+                    </div>
+                  </div>
+                </li>
+              </ul>
+            </li>
+            <li
+              aria-label="another line folder closed folder"
+              class="_folder_892ead"
+              data-type="folder"
+              draggable="true"
+              id="id-68cafccd-d7b8-4f92-9153-9df59eee4f06"
+            >
+              <div
+                class="_controls_892ead"
+              >
+                <div
+                  aria-label="drag handle"
+                  class="_dragHandle_892ead"
+                  title="Drag to move folder"
+                >
+                  <i
+                    class="fa-solid fa-grip-lines-vertical"
+                  />
+                </div>
+                <div
+                  class="_heading_892ead _notBase_892ead"
+                  title="Open folder in lines panel"
+                >
+                  <button
+                    aria-label="open another line folder folder in lines panel"
+                    class="_openToggle_892ead"
+                  />
+                  <h2>
+                    another line folder
+                  </h2>
+                  <button
+                    aria-label="rename folder"
+                    class="iconButton"
+                    title="Rename folder"
+                    type="button"
+                  >
+                    <i
+                      class="fa-solid fa-pencil"
+                    />
+                  </button>
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <section
+        aria-label="empty line panel"
+        class="_panel_8b8c73 _empty_8b8c73"
+      >
+        <p>
+          No lines to show
+        </p>
+      </section>
+    </div>
+  </main>
+</div>

--- a/src/features/repertoire/tests/__snapshots__/organisationOriginalFolderState.html
+++ b/src/features/repertoire/tests/__snapshots__/organisationOriginalFolderState.html
@@ -95,16 +95,20 @@
               ✔
             </span>
           </p>
-          <button
-            aria-label="new white folder"
-            class="iconButton"
-            title="New white folder"
-            type="button"
+          <div
+            class="_newTopLevelFolderButton_892ead"
           >
-            <i
-              class="fa-solid fa-folder-plus"
-            />
-          </button>
+            <button
+              aria-label="new top-level white folder"
+              class="iconButton"
+              title="New top-level white folder"
+              type="button"
+            >
+              <i
+                class="fa-solid fa-folder-plus"
+              />
+            </button>
+          </div>
           <ul
             aria-label="folders"
             class="_contents_892ead _base_892ead"

--- a/src/features/repertoire/tests/__snapshots__/organisationOriginalFolderState.html
+++ b/src/features/repertoire/tests/__snapshots__/organisationOriginalFolderState.html
@@ -95,34 +95,96 @@
               ✔
             </span>
           </p>
+          <button
+            aria-label="new white folder"
+            class="iconButton"
+            title="New white folder"
+            type="button"
+          >
+            <i
+              class="fa-solid fa-folder-plus"
+            />
+          </button>
           <ul
             aria-label="folders"
             class="_contents_892ead _base_892ead"
             role="list"
           >
             <li
-              aria-label="White open folder"
+              aria-label="line folder closed folder"
               class="_folder_892ead"
               data-type="folder"
-              draggable="false"
-              id="id-w"
+              draggable="true"
+              id="id-68cafccd-d7b8-4f92-9153-9df59eee4f03"
             >
               <div
                 class="_controls_892ead"
               >
                 <div
-                  class="_heading_892ead "
-                  title="Collapse folder"
+                  aria-label="drag handle"
+                  class="_dragHandle_892ead"
+                  title="Drag to move folder"
+                >
+                  <i
+                    class="fa-solid fa-grip-lines-vertical"
+                  />
+                </div>
+                <div
+                  class="_heading_892ead _notBase_892ead"
+                  title="Open folder in lines panel"
                 >
                   <button
-                    aria-label="close White folder "
+                    aria-label="open line folder folder in lines panel"
+                    class="_openToggle_892ead"
+                  />
+                  <h2>
+                    line folder
+                  </h2>
+                  <button
+                    aria-label="rename folder"
+                    class="iconButton"
+                    title="Rename folder"
+                    type="button"
+                  >
+                    <i
+                      class="fa-solid fa-pencil"
+                    />
+                  </button>
+                </div>
+              </div>
+            </li>
+            <li
+              aria-label="folder folder closed folder"
+              class="_folder_892ead"
+              data-type="folder"
+              draggable="true"
+              id="id-68cafccd-d7b8-4f92-9153-9df59eee4f04"
+            >
+              <div
+                class="_controls_892ead"
+              >
+                <div
+                  aria-label="drag handle"
+                  class="_dragHandle_892ead"
+                  title="Drag to move folder"
+                >
+                  <i
+                    class="fa-solid fa-grip-lines-vertical"
+                  />
+                </div>
+                <div
+                  class="_heading_892ead _notBase_892ead"
+                  title="Expand folder"
+                >
+                  <button
+                    aria-label="open folder folder folder "
                     class="_openToggle_892ead"
                   />
                   <i
-                    class="fa-solid fa-caret-down"
+                    class="fa-solid fa-caret-right"
                   />
                   <h2>
-                    White
+                    folder folder
                   </h2>
                   <button
                     aria-label="rename folder"
@@ -146,154 +208,49 @@
                   </button>
                 </div>
               </div>
-              <ul
-                aria-label="folders within White folder"
-                class="_contents_892ead"
-                role="list"
+            </li>
+            <li
+              aria-label="another line folder closed folder"
+              class="_folder_892ead"
+              data-type="folder"
+              draggable="true"
+              id="id-68cafccd-d7b8-4f92-9153-9df59eee4f06"
+            >
+              <div
+                class="_controls_892ead"
               >
-                <li
-                  aria-label="line folder closed folder"
-                  class="_folder_892ead"
-                  data-type="folder"
-                  draggable="true"
-                  id="id-68cafccd-d7b8-4f92-9153-9df59eee4f03"
+                <div
+                  aria-label="drag handle"
+                  class="_dragHandle_892ead"
+                  title="Drag to move folder"
                 >
-                  <div
-                    class="_controls_892ead"
-                  >
-                    <div
-                      aria-label="drag handle"
-                      class="_dragHandle_892ead"
-                      title="Drag to move folder"
-                    >
-                      <i
-                        class="fa-solid fa-grip-lines-vertical"
-                      />
-                    </div>
-                    <div
-                      class="_heading_892ead _notBase_892ead"
-                      title="Open folder in lines panel"
-                    >
-                      <button
-                        aria-label="open line folder folder in lines panel"
-                        class="_openToggle_892ead"
-                      />
-                      <h2>
-                        line folder
-                      </h2>
-                      <button
-                        aria-label="rename folder"
-                        class="iconButton"
-                        title="Rename folder"
-                        type="button"
-                      >
-                        <i
-                          class="fa-solid fa-pencil"
-                        />
-                      </button>
-                    </div>
-                  </div>
-                </li>
-                <li
-                  aria-label="folder folder closed folder"
-                  class="_folder_892ead"
-                  data-type="folder"
-                  draggable="true"
-                  id="id-68cafccd-d7b8-4f92-9153-9df59eee4f04"
+                  <i
+                    class="fa-solid fa-grip-lines-vertical"
+                  />
+                </div>
+                <div
+                  class="_heading_892ead _notBase_892ead"
+                  title="Open folder in lines panel"
                 >
-                  <div
-                    class="_controls_892ead"
+                  <button
+                    aria-label="open another line folder folder in lines panel"
+                    class="_openToggle_892ead"
+                  />
+                  <h2>
+                    another line folder
+                  </h2>
+                  <button
+                    aria-label="rename folder"
+                    class="iconButton"
+                    title="Rename folder"
+                    type="button"
                   >
-                    <div
-                      aria-label="drag handle"
-                      class="_dragHandle_892ead"
-                      title="Drag to move folder"
-                    >
-                      <i
-                        class="fa-solid fa-grip-lines-vertical"
-                      />
-                    </div>
-                    <div
-                      class="_heading_892ead _notBase_892ead"
-                      title="Expand folder"
-                    >
-                      <button
-                        aria-label="open folder folder folder "
-                        class="_openToggle_892ead"
-                      />
-                      <i
-                        class="fa-solid fa-caret-right"
-                      />
-                      <h2>
-                        folder folder
-                      </h2>
-                      <button
-                        aria-label="rename folder"
-                        class="iconButton"
-                        title="Rename folder"
-                        type="button"
-                      >
-                        <i
-                          class="fa-solid fa-pencil"
-                        />
-                      </button>
-                      <button
-                        aria-label="new folder"
-                        class="iconButton"
-                        title="New folder"
-                        type="button"
-                      >
-                        <i
-                          class="fa-solid fa-folder-plus"
-                        />
-                      </button>
-                    </div>
-                  </div>
-                </li>
-                <li
-                  aria-label="another line folder closed folder"
-                  class="_folder_892ead"
-                  data-type="folder"
-                  draggable="true"
-                  id="id-68cafccd-d7b8-4f92-9153-9df59eee4f06"
-                >
-                  <div
-                    class="_controls_892ead"
-                  >
-                    <div
-                      aria-label="drag handle"
-                      class="_dragHandle_892ead"
-                      title="Drag to move folder"
-                    >
-                      <i
-                        class="fa-solid fa-grip-lines-vertical"
-                      />
-                    </div>
-                    <div
-                      class="_heading_892ead _notBase_892ead"
-                      title="Open folder in lines panel"
-                    >
-                      <button
-                        aria-label="open another line folder folder in lines panel"
-                        class="_openToggle_892ead"
-                      />
-                      <h2>
-                        another line folder
-                      </h2>
-                      <button
-                        aria-label="rename folder"
-                        class="iconButton"
-                        title="Rename folder"
-                        type="button"
-                      >
-                        <i
-                          class="fa-solid fa-pencil"
-                        />
-                      </button>
-                    </div>
-                  </div>
-                </li>
-              </ul>
+                    <i
+                      class="fa-solid fa-pencil"
+                    />
+                  </button>
+                </div>
+              </div>
             </li>
           </ul>
         </div>

--- a/src/features/repertoire/tests/__snapshots__/organisationOriginalLineState.html
+++ b/src/features/repertoire/tests/__snapshots__/organisationOriginalLineState.html
@@ -95,16 +95,20 @@
               ✔
             </span>
           </p>
-          <button
-            aria-label="new white folder"
-            class="iconButton"
-            title="New white folder"
-            type="button"
+          <div
+            class="_newTopLevelFolderButton_892ead"
           >
-            <i
-              class="fa-solid fa-folder-plus"
-            />
-          </button>
+            <button
+              aria-label="new top-level white folder"
+              class="iconButton"
+              title="New top-level white folder"
+              type="button"
+            >
+              <i
+                class="fa-solid fa-folder-plus"
+              />
+            </button>
+          </div>
           <ul
             aria-label="folders"
             class="_contents_892ead _base_892ead"

--- a/src/features/repertoire/tests/__snapshots__/organisationOriginalLineState.html
+++ b/src/features/repertoire/tests/__snapshots__/organisationOriginalLineState.html
@@ -95,34 +95,96 @@
               ✔
             </span>
           </p>
+          <button
+            aria-label="new white folder"
+            class="iconButton"
+            title="New white folder"
+            type="button"
+          >
+            <i
+              class="fa-solid fa-folder-plus"
+            />
+          </button>
           <ul
             aria-label="folders"
             class="_contents_892ead _base_892ead"
             role="list"
           >
             <li
-              aria-label="White open folder"
+              aria-label="line folder open folder"
               class="_folder_892ead"
               data-type="folder"
-              draggable="false"
-              id="id-w"
+              draggable="true"
+              id="id-68cafccd-d7b8-4f92-9153-9df59eee4f03"
             >
               <div
                 class="_controls_892ead"
               >
                 <div
-                  class="_heading_892ead "
+                  aria-label="drag handle"
+                  class="_dragHandle_892ead"
+                  title="Drag to move folder"
+                >
+                  <i
+                    class="fa-solid fa-grip-lines-vertical"
+                  />
+                </div>
+                <div
+                  class="_heading_892ead _notBase_892ead"
+                  title="Open folder in lines panel"
+                >
+                  <button
+                    aria-label="open line folder folder in lines panel"
+                    class="_openToggle_892ead"
+                  />
+                  <h2>
+                    line folder
+                  </h2>
+                  <button
+                    aria-label="rename folder"
+                    class="iconButton"
+                    title="Rename folder"
+                    type="button"
+                  >
+                    <i
+                      class="fa-solid fa-pencil"
+                    />
+                  </button>
+                </div>
+              </div>
+            </li>
+            <li
+              aria-label="folder folder open folder"
+              class="_folder_892ead"
+              data-type="folder"
+              draggable="true"
+              id="id-68cafccd-d7b8-4f92-9153-9df59eee4f04"
+            >
+              <div
+                class="_controls_892ead"
+              >
+                <div
+                  aria-label="drag handle"
+                  class="_dragHandle_892ead"
+                  title="Drag to move folder"
+                >
+                  <i
+                    class="fa-solid fa-grip-lines-vertical"
+                  />
+                </div>
+                <div
+                  class="_heading_892ead _notBase_892ead"
                   title="Collapse folder"
                 >
                   <button
-                    aria-label="close White folder "
+                    aria-label="close folder folder folder "
                     class="_openToggle_892ead"
                   />
                   <i
                     class="fa-solid fa-caret-down"
                   />
                   <h2>
-                    White
+                    folder folder
                   </h2>
                   <button
                     aria-label="rename folder"
@@ -147,16 +209,16 @@
                 </div>
               </div>
               <ul
-                aria-label="folders within White folder"
+                aria-label="folders within folder folder folder"
                 class="_contents_892ead"
                 role="list"
               >
                 <li
-                  aria-label="line folder open folder"
+                  aria-label="empty folder closed folder"
                   class="_folder_892ead"
                   data-type="folder"
                   draggable="true"
-                  id="id-68cafccd-d7b8-4f92-9153-9df59eee4f03"
+                  id="id-68cafccd-d7b8-4f92-9153-9df59eee4f05"
                 >
                   <div
                     class="_controls_892ead"
@@ -175,57 +237,11 @@
                       title="Open folder in lines panel"
                     >
                       <button
-                        aria-label="open line folder folder in lines panel"
+                        aria-label="open empty folder folder in lines panel"
                         class="_openToggle_892ead"
                       />
                       <h2>
-                        line folder
-                      </h2>
-                      <button
-                        aria-label="rename folder"
-                        class="iconButton"
-                        title="Rename folder"
-                        type="button"
-                      >
-                        <i
-                          class="fa-solid fa-pencil"
-                        />
-                      </button>
-                    </div>
-                  </div>
-                </li>
-                <li
-                  aria-label="folder folder open folder"
-                  class="_folder_892ead"
-                  data-type="folder"
-                  draggable="true"
-                  id="id-68cafccd-d7b8-4f92-9153-9df59eee4f04"
-                >
-                  <div
-                    class="_controls_892ead"
-                  >
-                    <div
-                      aria-label="drag handle"
-                      class="_dragHandle_892ead"
-                      title="Drag to move folder"
-                    >
-                      <i
-                        class="fa-solid fa-grip-lines-vertical"
-                      />
-                    </div>
-                    <div
-                      class="_heading_892ead _notBase_892ead"
-                      title="Collapse folder"
-                    >
-                      <button
-                        aria-label="close folder folder folder "
-                        class="_openToggle_892ead"
-                      />
-                      <i
-                        class="fa-solid fa-caret-down"
-                      />
-                      <h2>
-                        folder folder
+                        empty folder
                       </h2>
                       <button
                         aria-label="rename folder"
@@ -247,122 +263,63 @@
                           class="fa-solid fa-folder-plus"
                         />
                       </button>
-                    </div>
-                  </div>
-                  <ul
-                    aria-label="folders within folder folder folder"
-                    class="_contents_892ead"
-                    role="list"
-                  >
-                    <li
-                      aria-label="empty folder closed folder"
-                      class="_folder_892ead"
-                      data-type="folder"
-                      draggable="true"
-                      id="id-68cafccd-d7b8-4f92-9153-9df59eee4f05"
-                    >
-                      <div
-                        class="_controls_892ead"
-                      >
-                        <div
-                          aria-label="drag handle"
-                          class="_dragHandle_892ead"
-                          title="Drag to move folder"
-                        >
-                          <i
-                            class="fa-solid fa-grip-lines-vertical"
-                          />
-                        </div>
-                        <div
-                          class="_heading_892ead _notBase_892ead"
-                          title="Open folder in lines panel"
-                        >
-                          <button
-                            aria-label="open empty folder folder in lines panel"
-                            class="_openToggle_892ead"
-                          />
-                          <h2>
-                            empty folder
-                          </h2>
-                          <button
-                            aria-label="rename folder"
-                            class="iconButton"
-                            title="Rename folder"
-                            type="button"
-                          >
-                            <i
-                              class="fa-solid fa-pencil"
-                            />
-                          </button>
-                          <button
-                            aria-label="new folder"
-                            class="iconButton"
-                            title="New folder"
-                            type="button"
-                          >
-                            <i
-                              class="fa-solid fa-folder-plus"
-                            />
-                          </button>
-                          <button
-                            aria-label="delete folder"
-                            class="iconButton"
-                            title="Delete folder"
-                            type="button"
-                          >
-                            <i
-                              class="fa-solid fa-trash"
-                            />
-                          </button>
-                        </div>
-                      </div>
-                    </li>
-                  </ul>
-                </li>
-                <li
-                  aria-label="another line folder closed folder"
-                  class="_folder_892ead"
-                  data-type="folder"
-                  draggable="true"
-                  id="id-68cafccd-d7b8-4f92-9153-9df59eee4f06"
-                >
-                  <div
-                    class="_controls_892ead"
-                  >
-                    <div
-                      aria-label="drag handle"
-                      class="_dragHandle_892ead"
-                      title="Drag to move folder"
-                    >
-                      <i
-                        class="fa-solid fa-grip-lines-vertical"
-                      />
-                    </div>
-                    <div
-                      class="_heading_892ead _notBase_892ead"
-                      title="Open folder in lines panel"
-                    >
                       <button
-                        aria-label="open another line folder folder in lines panel"
-                        class="_openToggle_892ead"
-                      />
-                      <h2>
-                        another line folder
-                      </h2>
-                      <button
-                        aria-label="rename folder"
+                        aria-label="delete folder"
                         class="iconButton"
-                        title="Rename folder"
+                        title="Delete folder"
                         type="button"
                       >
                         <i
-                          class="fa-solid fa-pencil"
+                          class="fa-solid fa-trash"
                         />
                       </button>
                     </div>
                   </div>
                 </li>
               </ul>
+            </li>
+            <li
+              aria-label="another line folder closed folder"
+              class="_folder_892ead"
+              data-type="folder"
+              draggable="true"
+              id="id-68cafccd-d7b8-4f92-9153-9df59eee4f06"
+            >
+              <div
+                class="_controls_892ead"
+              >
+                <div
+                  aria-label="drag handle"
+                  class="_dragHandle_892ead"
+                  title="Drag to move folder"
+                >
+                  <i
+                    class="fa-solid fa-grip-lines-vertical"
+                  />
+                </div>
+                <div
+                  class="_heading_892ead _notBase_892ead"
+                  title="Open folder in lines panel"
+                >
+                  <button
+                    aria-label="open another line folder folder in lines panel"
+                    class="_openToggle_892ead"
+                  />
+                  <h2>
+                    another line folder
+                  </h2>
+                  <button
+                    aria-label="rename folder"
+                    class="iconButton"
+                    title="Rename folder"
+                    type="button"
+                  >
+                    <i
+                      class="fa-solid fa-pencil"
+                    />
+                  </button>
+                </div>
+              </div>
             </li>
           </ul>
         </div>

--- a/src/features/repertoire/tests/folders.test.tsx
+++ b/src/features/repertoire/tests/folders.test.tsx
@@ -43,7 +43,7 @@ describe('New folder button', () => {
         renderRouter();
 
         expect(
-            screen.getByRole('button', { name: /new white folder/i })
+            screen.getByRole('button', { name: /new top-level white folder/i })
         ).toBeInTheDocument();
     });
 
@@ -145,7 +145,7 @@ describe('New folder button', () => {
         renderRouter();
 
         const newFolderButton = screen.getByRole('button', {
-            name: /new white folder/i,
+            name: /new top-level white folder/i,
         });
         await user.click(newFolderButton);
 

--- a/src/features/repertoire/tests/folders.test.tsx
+++ b/src/features/repertoire/tests/folders.test.tsx
@@ -38,12 +38,25 @@ describe('Switching repertoire tabs', () => {
 });
 
 describe('New folder button', () => {
-    it("Renders 'new folder' button when folder is empty", () => {
+    it("Renders top-level 'new folder' button", () => {
         helpers.setup.repertoire(helpers.repertoire.empty);
         renderRouter();
 
         expect(
-            screen.getByRole('button', { name: /new folder/i })
+            screen.getByRole('button', { name: /new white folder/i })
+        ).toBeInTheDocument();
+    });
+
+    it("Renders folder-specific 'new folder' button when folder is empty", () => {
+        helpers.setup.repertoire(helpers.repertoire.withFolderInWhite);
+        renderRouter();
+
+        const emptyFolder = screen.getByRole('listitem', {
+            name: /child closed folder/i,
+        });
+
+        expect(
+            within(emptyFolder).getByRole('button', { name: /new folder/i })
         ).toBeInTheDocument();
     });
 
@@ -51,12 +64,12 @@ describe('New folder button', () => {
         helpers.setup.repertoire(helpers.repertoire.withFolderInWhite);
         renderRouter();
 
-        const whiteFolder = screen.getByRole('listitem', {
-            name: /white open folder/i,
+        const folderFolder = screen.getByRole('listitem', {
+            name: /child closed folder/i,
         });
 
         expect(
-            within(whiteFolder).getAllByRole('button', {
+            within(folderFolder).getAllByRole('button', {
                 name: /new folder/i,
             })[0]
         ).toBeInTheDocument();
@@ -67,7 +80,7 @@ describe('New folder button', () => {
         renderRouter();
 
         const whiteFolder = screen.getByRole('listitem', {
-            name: /white.+folder/i,
+            name: /child closed folder/i,
         });
 
         expect(
@@ -85,7 +98,7 @@ describe('New folder button', () => {
     });
 
     it('Removes new folder button when new folder button clicked and form appears', async () => {
-        helpers.setup.repertoire(helpers.repertoire.empty);
+        helpers.setup.repertoire(helpers.repertoire.withFolderInWhite);
         const user = userEvent.setup();
         renderRouter();
 
@@ -115,7 +128,6 @@ describe('New folder button', () => {
             'button',
             { name: /open child folder/i }
         );
-        // open the first child folder
         await user.click(closableFolderOpenButton);
 
         const newFolderButton = within(closableFolder).getAllByRole('button', {
@@ -127,13 +139,13 @@ describe('New folder button', () => {
         expect(closableFolder).toHaveAccessibleName(/child open folder$/i);
     });
 
-    it('Adds new folder when new folder name submitted', async () => {
+    it('Adds new top-level folder when new folder name submitted', async () => {
         helpers.setup.repertoire(helpers.repertoire.empty);
         const user = userEvent.setup();
         renderRouter();
 
         const newFolderButton = screen.getByRole('button', {
-            name: /new folder/i,
+            name: /new white folder/i,
         });
         await user.click(newFolderButton);
 
@@ -147,12 +159,35 @@ describe('New folder button', () => {
         ).toBeInTheDocument();
     });
 
-    it('Discards new folder name form without submitting and renders new folder button when cancel button clicked', async () => {
-        helpers.setup.repertoire(helpers.repertoire.empty);
+    it('Adds new folder as a child of another folder', async () => {
+        helpers.setup.repertoire(helpers.repertoire.withFolderInWhite);
         const user = userEvent.setup();
         renderRouter();
 
-        const displayedFolderCount = screen.queryAllByRole('generic', {
+        const folder = screen.getByRole('listitem', {
+            name: /child closed folder/i,
+        });
+        const newFolderButton = screen.getByRole('button', {
+            name: /new folder/i,
+        });
+        await user.click(newFolderButton);
+
+        const newFolderNameInput = screen.getByRole('textbox', {
+            name: /name/i,
+        });
+        await user.type(newFolderNameInput, 'new folder name[Enter]');
+
+        expect(
+            within(folder).getByRole('heading', { name: /new folder name/i })
+        ).toBeInTheDocument();
+    });
+
+    it('Discards new folder name form without submitting and renders new folder button when cancel button clicked', async () => {
+        helpers.setup.repertoire(helpers.repertoire.withFolderInWhite);
+        const user = userEvent.setup();
+        renderRouter();
+
+        const displayedFolderCount = screen.queryAllByRole('listitem', {
             name: /folder$/i,
         }).length;
 
@@ -169,7 +204,7 @@ describe('New folder button', () => {
             screen.getByRole('button', { name: /new folder/i })
         ).toBeInTheDocument();
         expect(
-            screen.queryAllByRole('generic', { name: /folder$/i })
+            screen.queryAllByRole('listitem', { name: /folder$/i })
         ).toHaveLength(displayedFolderCount);
     });
 
@@ -205,7 +240,7 @@ describe('Renaming folder', () => {
     });
 
     it('Shows rename form when edit button clicked', async () => {
-        helpers.setup.repertoire(helpers.repertoire.empty);
+        helpers.setup.repertoire(helpers.repertoire.withFolderInWhite);
         const user = userEvent.setup();
         renderRouter();
 
@@ -220,11 +255,10 @@ describe('Renaming folder', () => {
     });
 
     it('Renames folder when rename form submitted', async () => {
-        helpers.setup.repertoire(helpers.repertoire.empty);
+        helpers.setup.repertoire(helpers.repertoire.withFolderInWhite);
         const user = userEvent.setup();
         renderRouter();
 
-        const oldFolderName = helpers.repertoire.empty.folders.w;
         const renameButton = screen.getByRole('button', {
             name: /rename folder/i,
         });
@@ -240,30 +274,31 @@ describe('Renaming folder', () => {
             screen.getByRole('listitem', { name: /^renamed folder/i })
         ).toBeInTheDocument();
         expect(
-            screen.queryByRole('listitem', { name: `${oldFolderName}` })
+            screen.queryByRole('listitem', { name: /child/i })
         ).not.toBeInTheDocument();
     });
 
     it('Prevents closing folder while rename form present', async () => {
-        helpers.setup.repertoire(helpers.repertoire.withFolderInWhite);
+        helpers.setup.repertoire(helpers.repertoire.withNestedFolders);
         const user = userEvent.setup();
         renderRouter();
 
         const closableFolder = screen.getByRole('listitem', {
-            name: /white open folder$/i,
+            name: /child closed folder$/i,
         });
-        const closableFolderCloseButton = within(closableFolder).getByRole(
+        const closableFolderToggleOpenButton = within(closableFolder).getByRole(
             'button',
-            { name: /close white folder/i }
+            { name: /open child folder/i }
         );
+        await user.click(closableFolderToggleOpenButton);
 
         const renameButton = within(closableFolder).getAllByRole('button', {
             name: /rename folder/i,
         })[0];
         await user.click(renameButton);
-        await user.click(closableFolderCloseButton);
+        await user.click(closableFolderToggleOpenButton);
 
-        expect(closableFolder).toHaveAccessibleName(/white open folder$/i);
+        expect(closableFolder).toHaveAccessibleName(/child open folder$/i);
     });
 
     it('Does not render new folder button when rename form present', async () => {

--- a/src/features/repertoire/tests/importExport.test.tsx
+++ b/src/features/repertoire/tests/importExport.test.tsx
@@ -81,7 +81,7 @@ describe('Import', () => {
 
     it('Saves valid repertoire string to local storage', async () => {
         const repertoireString =
-            '{"folders":{"w":{"name":"White","contains":"lines","children":["5ce93b80-bb2d-4351-a6ef-c3582ef34e0c"]},"b":{"name":"Black","contains":"folders","children":["70dcfb82-002d-4dac-94f1-9f7954220a19"]},"70dcfb82-002d-4dac-94f1-9f7954220a19":{"name":"test","contains":"lines","children":["077e2625-bb27-465d-837e-f1a8a5df7ff4","0985f53d-03a8-4eb6-9f98-2b33e9455287"]}},"lines":{"077e2625-bb27-465d-837e-f1a8a5df7ff4":{"player":"b","startingFEN":"rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1","PGN":"1... c5 2. d4 cxd4","notes":["","","",""]},"0985f53d-03a8-4eb6-9f98-2b33e9455287":{"player":"b","startingFEN":"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1","PGN":"1. d4 d5","notes":["","",""]},"5ce93b80-bb2d-4351-a6ef-c3582ef34e0c":{"player":"w","startingFEN":"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1","PGN":"1. e4 e5 2. Nc3 Nc6 3. Bc4 Bc5 4. Qg4","notes":["","","","","","","","Yes!"]}}}';
+            '{"folders":{"w":{"name":"White","contains":"folders","children":["68cafccd-d7b8-4f92-9153-9df59eee4f03"]},"b":{"name":"Black","contains":"folders","children":[]},"68cafccd-d7b8-4f92-9153-9df59eee4f03":{"name":"Child","contains":"folders","children":["68cafccd-d7b8-4f92-9153-9df59eee4f04"]},"68cafccd-d7b8-4f92-9153-9df59eee4f04":{"name":"Child of child","contains":"either","children":[]}},"lines":{}}';
 
         const user = await openImportDialog(helpers.repertoire.empty);
         const textarea = screen.getByRole('textbox', {
@@ -102,7 +102,7 @@ describe('Import', () => {
 
     it('Saves valid repertoire string from uploaded file to local storage', async () => {
         const repertoireString =
-            '{"folders":{"w":{"name":"White","contains":"lines","children":["5ce93b80-bb2d-4351-a6ef-c3582ef34e0c"]},"b":{"name":"Black","contains":"folders","children":["70dcfb82-002d-4dac-94f1-9f7954220a19"]},"70dcfb82-002d-4dac-94f1-9f7954220a19":{"name":"test","contains":"lines","children":["077e2625-bb27-465d-837e-f1a8a5df7ff4","0985f53d-03a8-4eb6-9f98-2b33e9455287"]}},"lines":{"077e2625-bb27-465d-837e-f1a8a5df7ff4":{"player":"b","startingFEN":"rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1","PGN":"1... c5 2. d4 cxd4","notes":["","","",""]},"0985f53d-03a8-4eb6-9f98-2b33e9455287":{"player":"b","startingFEN":"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1","PGN":"1. d4 d5","notes":["","",""]},"5ce93b80-bb2d-4351-a6ef-c3582ef34e0c":{"player":"w","startingFEN":"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1","PGN":"1. e4 e5 2. Nc3 Nc6 3. Bc4 Bc5 4. Qg4","notes":["","","","","","","","Yes!"]}}}';
+            '{"folders":{"w":{"name":"White","contains":"folders","children":["68cafccd-d7b8-4f92-9153-9df59eee4f03"]},"b":{"name":"Black","contains":"folders","children":[]},"68cafccd-d7b8-4f92-9153-9df59eee4f03":{"name":"Child","contains":"folders","children":["68cafccd-d7b8-4f92-9153-9df59eee4f04"]},"68cafccd-d7b8-4f92-9153-9df59eee4f04":{"name":"Child of child","contains":"either","children":[]}},"lines":{}}';
 
         const user = await openImportDialog(helpers.repertoire.empty);
         const fileTab = screen.getByRole('tab', { name: /import from file/i });
@@ -129,39 +129,50 @@ describe('Import', () => {
         expect(window.location.reload).toHaveBeenCalled();
     });
 
-    it('Invalidates invalid repertoire string data', async () => {
-        const repertoireString = 'flobadobdob';
+    it.each([
+        ['flobadobdob'],
+        [
+            // base w folder can only contain folders
+            '{"folders":{"w":{"name":"White","contains":"lines","children":["5ce93b80-bb2d-4351-a6ef-c3582ef34e0c"]},"b":{"name":"Black","contains":"folders","children":["70dcfb82-002d-4dac-94f1-9f7954220a19"]},"70dcfb82-002d-4dac-94f1-9f7954220a19":{"name":"test","contains":"lines","children":["077e2625-bb27-465d-837e-f1a8a5df7ff4","0985f53d-03a8-4eb6-9f98-2b33e9455287"]}},"lines":{"077e2625-bb27-465d-837e-f1a8a5df7ff4":{"player":"b","startingFEN":"rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1","PGN":"1... c5 2. d4 cxd4","notes":["","","",""]},"0985f53d-03a8-4eb6-9f98-2b33e9455287":{"player":"b","startingFEN":"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1","PGN":"1. d4 d5","notes":["","",""]},"5ce93b80-bb2d-4351-a6ef-c3582ef34e0c":{"player":"w","startingFEN":"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1","PGN":"1. e4 e5 2. Nc3 Nc6 3. Bc4 Bc5 4. Qg4","notes":["","","","","","","","Yes!"]}}}',
+        ],
+    ])(
+        'Invalidates invalid repertoire string data',
+        async (repertoireString) => {
+            const user = await openImportDialog(helpers.repertoire.empty);
+            // ensure setup storage calls don't contaminate test
+            vi.resetAllMocks();
 
-        const user = await openImportDialog(helpers.repertoire.empty);
-        // ensure setup storage calls don't contaminate test
-        vi.resetAllMocks();
+            const fileTab = screen.getByRole('tab', {
+                name: /import from file/i,
+            });
+            await user.click(fileTab);
 
-        const fileTab = screen.getByRole('tab', { name: /import from file/i });
-        await user.click(fileTab);
+            const fileInput = screen.getByLabelText(
+                /repertoire file \(.json or .txt\)/i
+            ) as HTMLInputElement;
+            // IMPORTANT! Bug in user-event where file inputs fail validation when required
+            // https://github.com/testing-library/user-event/issues/801
+            fileInput.required = false;
+            const importButton = screen.getByRole('button', {
+                name: /^import$/i,
+            });
 
-        const fileInput = screen.getByLabelText(
-            /repertoire file \(.json or .txt\)/i
-        ) as HTMLInputElement;
-        // IMPORTANT! Bug in user-event where file inputs fail validation when required
-        // https://github.com/testing-library/user-event/issues/801
-        fileInput.required = false;
-        const importButton = screen.getByRole('button', { name: /^import$/i });
+            await user.upload(
+                fileInput,
+                new File([repertoireString], 'repertoire.txt', {
+                    type: 'text/plain',
+                })
+            );
+            await user.click(importButton);
 
-        await user.upload(
-            fileInput,
-            new File([repertoireString], 'repertoire.txt', {
-                type: 'text/plain',
-            })
-        );
-        await user.click(importButton);
-
-        expect(repertoireSetSpy).not.toHaveBeenCalled();
-        expect(lineIDsToTrainSetSpy).not.toHaveBeenCalled();
-        expect(window.location.reload).not.toHaveBeenCalled();
-        expect(
-            screen.getByText(/invalid repertoire data/i)
-        ).toBeInTheDocument();
-    });
+            expect(repertoireSetSpy).not.toHaveBeenCalled();
+            expect(lineIDsToTrainSetSpy).not.toHaveBeenCalled();
+            expect(window.location.reload).not.toHaveBeenCalled();
+            expect(
+                screen.getByText(/invalid repertoire data/i)
+            ).toBeInTheDocument();
+        }
+    );
 
     it('Removes validation error message when switching tabs', async () => {
         const user = await openImportDialog(helpers.repertoire.empty);

--- a/src/features/repertoire/tests/importExport.test.tsx
+++ b/src/features/repertoire/tests/importExport.test.tsx
@@ -169,7 +169,7 @@ describe('Import', () => {
             expect(lineIDsToTrainSetSpy).not.toHaveBeenCalled();
             expect(window.location.reload).not.toHaveBeenCalled();
             expect(
-                screen.getByText(/invalid repertoire data/i)
+                await screen.findByText(/invalid repertoire data/i)
             ).toBeInTheDocument();
         }
     );

--- a/src/features/repertoire/tests/lineEditor.test.tsx
+++ b/src/features/repertoire/tests/lineEditor.test.tsx
@@ -17,10 +17,10 @@ async function openLineFolderInPanel(
     render(<RouterProvider router={testRouter} />);
 
     const user = userEvent.setup();
-    const whiteFolder = screen.getByRole('button', {
-        name: /open white folder in lines panel/i,
+    const linesFolder = screen.getByRole('button', {
+        name: /open child folder in lines panel/i,
     });
-    await user.click(whiteFolder);
+    await user.click(linesFolder);
     return user;
 }
 
@@ -173,7 +173,7 @@ describe('Validation', () => {
         const newPGN = '1. d4 d5 2. c4';
 
         const user = await openLineFolderInPanel();
-        const linesPanel = screen.getByRole('region', { name: /white/i });
+        const linesPanel = screen.getByRole('region', { name: /child/i });
 
         expect(within(linesPanel).getAllByRole('listitem')).toHaveLength(1);
         expect(screen.queryByText(`PGN: ${newPGN}`)).not.toBeInTheDocument();

--- a/src/features/repertoire/tests/lineEditor.test.tsx
+++ b/src/features/repertoire/tests/lineEditor.test.tsx
@@ -1,13 +1,11 @@
 import { createMemoryRouter, RouterProvider } from 'react-router';
-import { describe, it, expect, afterEach } from 'vitest';
-import { cleanup, render, screen, within } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { routes } from '@/app/routes';
 import { helpers } from '@/testing/helpers';
 import { STANDARD_STARTING_FEN } from '@/util/constants';
 import type { Repertoire } from '@/types/repertoire';
-
-afterEach(cleanup);
 
 async function openLineFolderInPanel(
     repertoire: Repertoire = helpers.repertoire.withLineInWhite

--- a/src/features/repertoire/tests/lines.test.tsx
+++ b/src/features/repertoire/tests/lines.test.tsx
@@ -18,27 +18,27 @@ describe('Lines panel', () => {
         const user = userEvent.setup();
         renderRouter();
 
-        const whiteFolder = screen.getByRole('button', {
-            name: /open white folder in lines panel/i,
+        const lineFolder = screen.getByRole('button', {
+            name: /open child folder in lines panel/i,
         });
-        await user.click(whiteFolder);
+        await user.click(lineFolder);
 
         expect(
-            screen.getByRole('region', { name: testRepertoire.folders.w.name })
+            screen.getByRole('region', { name: testRepertoire.folders[UUIDS.folders[0]].name })
         ).toBeInTheDocument();
     });
 
-    it("Lists open lines folder's lines in line panel", async () => {
+    it("Lists open linesFolder's lines in line panel", async () => {
         const testRepertoire = helpers.setup.repertoire(
             helpers.repertoire.withLineInWhite
         );
         const user = userEvent.setup();
         renderRouter();
 
-        const whiteFolder = screen.getByRole('button', {
-            name: /open white folder in lines panel/i,
+        const lineFolder = screen.getByRole('button', {
+            name: /open child folder in lines panel/i,
         });
-        await user.click(whiteFolder);
+        await user.click(lineFolder);
 
         const line = testRepertoire.lines[UUIDS.lines[0]];
         expect(
@@ -52,10 +52,10 @@ describe('Lines panel', () => {
         const user = userEvent.setup();
         renderRouter();
 
-        const whiteFolder = screen.getByRole('button', {
-            name: /open white folder in lines panel/i,
+        const lineFolder = screen.getByRole('button', {
+            name: /open child folder in lines panel/i,
         });
-        await user.click(whiteFolder);
+        await user.click(lineFolder);
 
         expect(screen.getByText(/no moves set/i)).toBeInTheDocument();
     });
@@ -65,10 +65,10 @@ describe('Lines panel', () => {
         const user = userEvent.setup();
         renderRouter();
 
-        const whiteFolder = screen.getByRole('button', {
-            name: /open white folder in lines panel/i,
+        const lineFolder = screen.getByRole('button', {
+            name: /open child folder in lines panel/i,
         });
-        await user.click(whiteFolder);
+        await user.click(lineFolder);
 
         expect(
             screen.queryByText(/custom starting fen:/i)
@@ -82,35 +82,35 @@ describe('Lines panel', () => {
         const user = userEvent.setup();
         renderRouter();
 
-        const whiteFolder = screen.getByRole('button', {
-            name: /open white folder in lines panel/i,
+        const lineFolder = screen.getByRole('button', {
+            name: /open child folder in lines panel/i,
         });
-        await user.click(whiteFolder);
+        await user.click(lineFolder);
 
         const line = testRepertoire.lines[UUIDS.lines[0]];
         expect(screen.getByText(line.startingFEN)).toBeInTheDocument();
     });
 
     it('Does not render new line link if open folder contains other folders', async () => {
-        helpers.setup.repertoire(helpers.repertoire.empty);
+        helpers.setup.repertoire(helpers.repertoire.withFolderInWhite);
         const user = userEvent.setup();
         renderRouter();
 
-        const whiteFolder = screen.getByRole('listitem', {
-            name: /white.*folder/i,
+        const emptyFolder = screen.getByRole('listitem', {
+            name: /child closed folder/i,
         });
 
         // open White folder in panel (opens because it could contain lines)
-        const whiteFolderOpenButton = within(whiteFolder).getByRole('button', {
-            name: /open white folder in lines panel/i,
+        const emptyFolderOpenButton = within(emptyFolder).getByRole('button', {
+            name: /open child folder in lines panel/i,
         });
-        await user.click(whiteFolderOpenButton);
+        await user.click(emptyFolderOpenButton);
 
         expect(
             screen.getByRole('link', { name: /new line/i })
         ).toBeInTheDocument();
 
-        const newFolderButton = within(whiteFolder).getByRole('button', {
+        const newFolderButton = within(emptyFolder).getByRole('button', {
             name: /new folder/i,
         });
         await user.click(newFolderButton);

--- a/src/features/repertoire/tests/lines.test.tsx
+++ b/src/features/repertoire/tests/lines.test.tsx
@@ -24,7 +24,9 @@ describe('Lines panel', () => {
         await user.click(lineFolder);
 
         expect(
-            screen.getByRole('region', { name: testRepertoire.folders[UUIDS.folders[0]].name })
+            screen.getByRole('region', {
+                name: testRepertoire.folders[UUIDS.folders[0]].name,
+            })
         ).toBeInTheDocument();
     });
 

--- a/src/features/repertoire/tests/localStorage.test.tsx
+++ b/src/features/repertoire/tests/localStorage.test.tsx
@@ -143,7 +143,7 @@ describe('Editing repertoire', () => {
         renderRouter();
 
         const newFolderButton = screen.getByRole('button', {
-            name: /new white folder/i,
+            name: /new top-level white folder/i,
         });
         await user.click(newFolderButton);
         await user.keyboard('added[Space]folder[Enter]');

--- a/src/features/repertoire/tests/organisation.test.tsx
+++ b/src/features/repertoire/tests/organisation.test.tsx
@@ -89,47 +89,32 @@ describe('Moving folders', () => {
         helpers.setup.repertoire(helpers.repertoire.manyFoldersAndLines);
         const { container } = renderRouter();
 
-        const lineFolder = screen.getByRole('listitem', {
-            name: /^line folder/i,
-        });
-        const whiteFolder = screen.getByRole('listitem', { name: /white/i });
-        await expect(container).toMatchFileSnapshot(
-            './__snapshots__/organisationOriginalFolderState.html'
-        );
-
-        // user-events cannot simulate drag* events - must manually fire
-        fireEvent.drag(lineFolder);
-        fireEvent.drop(whiteFolder, {
-            dataTransfer: {
-                getData: () => `folder ${convert.htmlIdToUuid(lineFolder.id)}`,
-            },
-        });
-        await expect(container).toMatchFileSnapshot(
-            './__snapshots__/organisationOriginalFolderState.html'
-        );
-    });
-
-    it('Prevents dragging base colour folders', async () => {
-        helpers.setup.repertoire(helpers.repertoire.manyFoldersAndLines);
-        const { container } = renderRouter();
-
+        const user = userEvent.setup();
         const folderFolder = screen.getByRole('listitem', {
-            name: /folder folder/i,
+            name: /^folder folder/i,
         });
-        const whiteFolder = screen.getByRole('listitem', { name: /white/i });
+        const openFolderFolderButton = within(folderFolder).getByRole(
+            'button',
+            { name: /open folder folder/i }
+        );
+        await user.click(openFolderFolderButton);
+
+        const emptyFolder = screen.getByRole('listitem', {
+            name: /^empty folder/i,
+        });
         await expect(container).toMatchFileSnapshot(
-            './__snapshots__/organisationOriginalFolderState.html'
+            './__snapshots__/organisationNestedFolderState.html'
         );
 
         // user-events cannot simulate drag* events - must manually fire
-        fireEvent.drag(whiteFolder);
+        fireEvent.drag(emptyFolder);
         fireEvent.drop(folderFolder, {
             dataTransfer: {
-                getData: () => `folder ${convert.htmlIdToUuid(whiteFolder.id)}`,
+                getData: () => `folder ${convert.htmlIdToUuid(emptyFolder.id)}`,
             },
         });
         await expect(container).toMatchFileSnapshot(
-            './__snapshots__/organisationOriginalFolderState.html'
+            './__snapshots__/organisationNestedFolderState.html'
         );
     });
 

--- a/src/features/repertoire/tests/page.test.tsx
+++ b/src/features/repertoire/tests/page.test.tsx
@@ -58,10 +58,10 @@ describe('Initial elements', () => {
         const user = userEvent.setup();
         renderRouter();
 
-        const whiteFolder = screen.getByRole('button', {
-            name: /open white folder in lines panel/i,
+        const linesFolder = screen.getByRole('button', {
+            name: /open child of white folder in lines panel/i,
         });
-        await user.click(whiteFolder);
+        await user.click(linesFolder);
 
         const lines = within(
             screen.getByRole('list', { name: /lines/i })
@@ -80,10 +80,10 @@ describe('Initial elements', () => {
         const user = userEvent.setup();
         renderRouter();
 
-        const whiteFolder = screen.getByRole('button', {
-            name: /open white folder in lines panel/i,
+        const linesFolder = screen.getByRole('button', {
+            name: /open child of white folder in lines panel/i,
         });
-        await user.click(whiteFolder);
+        await user.click(linesFolder);
 
         const lines = within(
             screen.getByRole('list', { name: /lines/i })

--- a/src/features/trainer/tests/lineLink.test.tsx
+++ b/src/features/trainer/tests/lineLink.test.tsx
@@ -55,7 +55,7 @@ describe('"Study line" link', () => {
             helpers.testRepertoire.withSingleWhiteLine,
             [UUIDS.lines[0]]
         );
-        const testLineParentFolder = testRepertoire.folders.w;
+        const testLineParentFolder = testRepertoire.folders[UUIDS.folders[0]];
         const testLineID = Object.keys(testRepertoire.lines)[0];
         const studyLineRouter = createMemoryRouter(routes, {
             initialEntries: [`/repertoire?line=${testLineID}`],

--- a/src/hooks/useRepertoire.ts
+++ b/src/hooks/useRepertoire.ts
@@ -44,14 +44,16 @@ export function useRepertoire(repertoire: Repertoire) {
             const oldParentChildrenWithoutFolder = oldParent.children.filter(
                 (ids) => ids !== idToMove
             );
+            const isBaseFolder = oldParentId === 'w' || oldParentId === 'b';
 
             setFolders({
                 ...folders,
                 [oldParentId]: {
                     ...oldParent,
-                    contains: oldParentChildrenWithoutFolder.length
-                        ? 'folders'
-                        : 'either',
+                    contains:
+                        isBaseFolder || oldParentChildrenWithoutFolder.length
+                            ? 'folders'
+                            : 'either',
                     children: oldParentChildrenWithoutFolder,
                 },
                 [newParentId]: {
@@ -80,14 +82,16 @@ export function useRepertoire(repertoire: Repertoire) {
             const oldParentChildrenWithoutFolder = oldParent.children.filter(
                 (ids) => ids !== idToDelete
             );
+            const isBaseFolder = oldParentId === 'w' || oldParentId === 'b';
 
             setFolders({
                 ...remainingFolders,
                 [oldParentId]: {
                     ...oldParent,
-                    contains: oldParentChildrenWithoutFolder.length
-                        ? 'folders'
-                        : 'either',
+                    contains:
+                        isBaseFolder || oldParentChildrenWithoutFolder.length
+                            ? 'folders'
+                            : 'either',
                     children: oldParentChildrenWithoutFolder,
                 },
             });
@@ -97,7 +101,7 @@ export function useRepertoire(repertoire: Repertoire) {
     const lineMethods = {
         create(
             { player, startingFEN, PGN, notes }: RepertoireLine,
-            parent: RepertoireFolderID
+            parent: UUID
         ): void {
             const newLineUUID = crypto.randomUUID();
             const newParentFolder = {
@@ -118,7 +122,7 @@ export function useRepertoire(repertoire: Repertoire) {
         ): void {
             setLines({ ...lines, [id]: { player, startingFEN, PGN, notes } });
         },
-        updateLocation(idToMove: UUID, newParentId: RepertoireFolderID): void {
+        updateLocation(idToMove: UUID, newParentId: UUID): void {
             const [oldParentId, oldParent] = findParentFolder(
                 idToMove,
                 folders

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,7 +5,8 @@ import '@/app/global.css';
 import '@/app/reset.css';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { createBrowserRouter, RouterProvider } from 'react-router';
+import { createBrowserRouter } from 'react-router';
+import { RouterProvider } from 'react-router/dom';
 import { routes } from './app/routes';
 
 const router = createBrowserRouter(routes);

--- a/src/testing/helpers.ts
+++ b/src/testing/helpers.ts
@@ -1,9 +1,9 @@
 import { renderHook, screen } from '@testing-library/react';
+import { useDeepContainsSelectedLine } from '@/hooks/useDeepContainsSelectedLine';
 import { useRepertoire } from '@/hooks/useRepertoire';
-import { STANDARD_STARTING_FEN } from '@/util/constants';
+import { EMPTY_REPERTOIRE, STANDARD_STARTING_FEN } from '@/util/constants';
 import type { UUID } from '@/types/utility';
 import type { Repertoire, RepertoireFolderID } from '@/types/repertoire';
-import { useDeepContainsSelectedLine } from '@/hooks/useDeepContainsSelectedLine';
 
 export const UUIDS: Record<'folders' | 'lines', UUID[]> = {
     lines: [
@@ -21,13 +21,7 @@ export const UUIDS: Record<'folders' | 'lines', UUID[]> = {
 
 const repertoire = {
     get empty(): Repertoire {
-        return {
-            folders: {
-                w: { name: 'White', contains: 'either', children: [] },
-                b: { name: 'Black', contains: 'either', children: [] },
-            },
-            lines: {},
-        };
+        return EMPTY_REPERTOIRE;
     },
     get withFolderInWhite(): Repertoire {
         return {
@@ -37,7 +31,7 @@ const repertoire = {
                     contains: 'folders',
                     children: [UUIDS.folders[0]],
                 },
-                b: { name: 'Black', contains: 'either', children: [] },
+                b: { name: 'Black', contains: 'folders', children: [] },
                 [UUIDS.folders[0]]: {
                     name: 'Child',
                     contains: 'either',
@@ -52,10 +46,15 @@ const repertoire = {
             folders: {
                 w: {
                     name: 'White',
+                    contains: 'folders',
+                    children: [UUIDS.folders[0]],
+                },
+                b: { name: 'Black', contains: 'folders', children: [] },
+                [UUIDS.folders[0]]: {
+                    name: 'Child',
                     contains: 'lines',
                     children: [UUIDS.lines[0]],
                 },
-                b: { name: 'Black', contains: 'either', children: [] },
             },
             lines: {
                 [UUIDS.lines[0]]: {
@@ -73,10 +72,15 @@ const repertoire = {
             folders: {
                 w: {
                     name: 'White',
+                    contains: 'folders',
+                    children: [UUIDS.folders[0]],
+                },
+                b: { name: 'Black', contains: 'folders', children: [] },
+                [UUIDS.folders[0]]: {
+                    name: 'Child',
                     contains: 'lines',
                     children: [UUIDS.lines[0]],
                 },
-                b: { name: 'Black', contains: 'either', children: [] },
             },
             lines: {
                 [UUIDS.lines[0]]: {
@@ -94,10 +98,15 @@ const repertoire = {
             folders: {
                 w: {
                     name: 'White',
+                    contains: 'folders',
+                    children: [UUIDS.folders[0]],
+                },
+                b: { name: 'Black', contains: 'folders', children: [] },
+                [UUIDS.folders[0]]: {
+                    name: 'Child',
                     contains: 'lines',
                     children: [UUIDS.lines[0]],
                 },
-                b: { name: 'Black', contains: 'either', children: [] },
             },
             lines: {
                 [UUIDS.lines[0]]: {
@@ -115,10 +124,15 @@ const repertoire = {
             folders: {
                 w: {
                     name: 'White',
+                    contains: 'folders',
+                    children: [UUIDS.folders[0]],
+                },
+                b: { name: 'Black', contains: 'folders', children: [] },
+                [UUIDS.folders[0]]: {
+                    name: 'Child',
                     contains: 'lines',
                     children: [UUIDS.lines[0]],
                 },
-                b: { name: 'Black', contains: 'either', children: [] },
             },
             lines: {
                 [UUIDS.lines[0]]: {
@@ -144,10 +158,15 @@ const repertoire = {
             folders: {
                 w: {
                     name: 'White',
+                    contains: 'folders',
+                    children: [UUIDS.folders[0]],
+                },
+                b: { name: 'Black', contains: 'folders', children: [] },
+                [UUIDS.folders[0]]: {
+                    name: 'Child',
                     contains: 'lines',
                     children: [UUIDS.lines[0]],
                 },
-                b: { name: 'Black', contains: 'either', children: [] },
             },
             lines: {
                 [UUIDS.lines[0]]: {
@@ -172,7 +191,7 @@ const repertoire = {
                         UUIDS.folders[3],
                     ],
                 },
-                b: { name: 'Black', contains: 'either', children: [] },
+                b: { name: 'Black', contains: 'folders', children: [] },
                 [UUIDS.folders[0]]: {
                     name: 'line folder',
                     contains: 'lines',
@@ -227,7 +246,7 @@ const repertoire = {
                     contains: 'folders',
                     children: [UUIDS.folders[0]],
                 },
-                b: { name: 'Black', contains: 'either', children: [] },
+                b: { name: 'Black', contains: 'folders', children: [] },
                 [UUIDS.folders[0]]: {
                     name: 'Child',
                     contains: 'folders',
@@ -250,10 +269,15 @@ const testRepertoire = {
             folders: {
                 w: {
                     name: 'White',
+                    contains: 'folders',
+                    children: [UUIDS.folders[0]],
+                },
+                b: { name: 'Black', contains: 'folders', children: [] },
+                [UUIDS.folders[0]]: {
+                    name: 'Child',
                     contains: 'lines',
                     children: [UUIDS.lines[0]],
                 },
-                b: { name: 'Black', contains: 'either', children: [] },
             },
             lines: {
                 [UUIDS.lines[0]]: {
@@ -268,9 +292,14 @@ const testRepertoire = {
     get withSingleBlackLine(): Repertoire {
         return {
             folders: {
-                w: { name: 'White', contains: 'either', children: [] },
+                w: { name: 'White', contains: 'folders', children: [] },
                 b: {
                     name: 'Black',
+                    contains: 'folders',
+                    children: [UUIDS.folders[0]],
+                },
+                [UUIDS.folders[0]]: {
+                    name: 'Child',
                     contains: 'lines',
                     children: [UUIDS.lines[0]],
                 },
@@ -290,10 +319,15 @@ const testRepertoire = {
             folders: {
                 w: {
                     name: 'White',
+                    contains: 'folders',
+                    children: [UUIDS.folders[0]],
+                },
+                b: { name: 'Black', contains: 'folders', children: [] },
+                [UUIDS.folders[0]]: {
+                    name: 'Child',
                     contains: 'lines',
                     children: [UUIDS.lines[0]],
                 },
-                b: { name: 'Black', contains: 'either', children: [] },
             },
             lines: {
                 [UUIDS.lines[0]]: {
@@ -309,9 +343,14 @@ const testRepertoire = {
     get withSingleBlackMidwayLine(): Repertoire {
         return {
             folders: {
-                w: { name: 'White', contains: 'either', children: [] },
+                w: { name: 'White', contains: 'folders', children: [] },
                 b: {
                     name: 'Black',
+                    contains: 'folders',
+                    children: [UUIDS.folders[0]],
+                },
+                [UUIDS.folders[0]]: {
+                    name: 'Child',
                     contains: 'lines',
                     children: [UUIDS.lines[0]],
                 },
@@ -327,13 +366,17 @@ const testRepertoire = {
             },
         };
     },
-
     get forHintsTesting(): Repertoire {
         return {
             folders: {
-                w: { name: 'White', contains: 'either', children: [] },
+                w: { name: 'White', contains: 'folders', children: [] },
                 b: {
                     name: 'Black',
+                    contains: 'folders',
+                    children: [UUIDS.folders[0]],
+                },
+                [UUIDS.folders[0]]: {
+                    name: 'First',
                     contains: 'lines',
                     children: [UUIDS.lines[0], UUIDS.lines[1]],
                 },
@@ -359,11 +402,21 @@ const testRepertoire = {
             folders: {
                 w: {
                     name: 'White',
-                    contains: 'lines',
-                    children: [UUIDS.lines[0], UUIDS.lines[2]],
+                    contains: 'folders',
+                    children: [UUIDS.folders[0]],
                 },
                 b: {
                     name: 'Black',
+                    contains: 'folders',
+                    children: [UUIDS.folders[1]],
+                },
+                [UUIDS.folders[0]]: {
+                    name: 'Child of white',
+                    contains: 'lines',
+                    children: [UUIDS.lines[0], UUIDS.lines[2]],
+                },
+                [UUIDS.folders[1]]: {
+                    name: 'Child of black',
                     contains: 'lines',
                     children: [UUIDS.lines[1]],
                 },
@@ -395,11 +448,21 @@ const testRepertoire = {
             folders: {
                 w: {
                     name: 'White',
-                    contains: 'lines',
-                    children: [UUIDS.lines[0], UUIDS.lines[2]],
+                    contains: 'folders',
+                    children: [UUIDS.folders[0]],
                 },
                 b: {
                     name: 'Black',
+                    contains: 'folders',
+                    children: [UUIDS.folders[1]],
+                },
+                [UUIDS.folders[0]]: {
+                    name: 'Child of white',
+                    contains: 'lines',
+                    children: [UUIDS.lines[0], UUIDS.lines[2]],
+                },
+                [UUIDS.folders[1]]: {
+                    name: 'Child of black',
                     contains: 'lines',
                     children: [UUIDS.lines[1]],
                 },
@@ -430,15 +493,7 @@ const testRepertoire = {
 
 const hooks = {
     callUseRepertoire() {
-        return renderHook(() =>
-            useRepertoire({
-                folders: {
-                    w: { name: 'White', contains: 'either', children: [] },
-                    b: { name: 'Black', contains: 'either', children: [] },
-                },
-                lines: {},
-            })
-        );
+        return renderHook(() => useRepertoire(EMPTY_REPERTOIRE));
     },
     callUseDeepContainsSelectedLine(
         folders: Repertoire['folders'],

--- a/src/testing/helpers.ts
+++ b/src/testing/helpers.ts
@@ -492,8 +492,8 @@ const testRepertoire = {
 };
 
 const hooks = {
-    callUseRepertoire() {
-        return renderHook(() => useRepertoire(EMPTY_REPERTOIRE));
+    callUseRepertoire(repertoire: Repertoire = EMPTY_REPERTOIRE) {
+        return renderHook(() => useRepertoire(repertoire));
     },
     callUseDeepContainsSelectedLine(
         folders: Repertoire['folders'],

--- a/src/types/repertoire.ts
+++ b/src/types/repertoire.ts
@@ -37,12 +37,9 @@ export type RepertoireWithMethods = Repertoire & {
         delete: (id: RepertoireFolderID) => boolean;
     };
     lines: {
-        create: (line: RepertoireLine, parent: RepertoireFolderID) => void;
+        create: (line: RepertoireLine, parent: UUID) => void;
         updateLine: (id: UUID, line: RepertoireLine) => void;
-        updateLocation: (
-            idToMove: UUID,
-            newParentId: RepertoireFolderID
-        ) => void;
+        updateLocation: (idToMove: UUID, newParentId: UUID) => void;
         delete: (id: UUID) => void;
     };
 };

--- a/src/types/repertoire.ts
+++ b/src/types/repertoire.ts
@@ -1,5 +1,5 @@
 import type { Colour } from './chessboard';
-import type { NonEmptyArray, UUID } from './utility';
+import type { Prettify, UUID } from './utility';
 
 export type LineNotes = [string, ...string[]];
 export type RepertoireLine = {
@@ -13,18 +13,21 @@ type RepertoireLines = Record<UUID, RepertoireLine>;
 
 type Folder = { name: string };
 type EmptyFolder = Folder & { contains: 'either'; children: [] };
-type NonEmptyFolder = Folder & {
+type PopulatedFolder = Folder & {
     contains: 'folders' | 'lines';
-    children: NonEmptyArray<UUID>;
+    children: UUID[];
 };
-export type RepertoireFolder = EmptyFolder | NonEmptyFolder;
-type RepertoireFolders = Record<Colour | UUID, RepertoireFolder>;
+export type RepertoireFolder = EmptyFolder | PopulatedFolder;
+type BaseFolder = Prettify<PopulatedFolder & { contains: 'folders' }>;
 
-export type RepertoireFolderID = keyof RepertoireFolders;
+export type RepertoireFolderID = UUID | Colour;
 
-export type Repertoire = { folders: RepertoireFolders; lines: RepertoireLines };
-export type RepertoireWithMethods = {
-    folders: RepertoireFolders & {
+export type Repertoire = {
+    folders: { w: BaseFolder; b: BaseFolder; [id: UUID]: RepertoireFolder };
+    lines: RepertoireLines;
+};
+export type RepertoireWithMethods = Repertoire & {
+    folders: {
         create: (name: string, parent: RepertoireFolderID) => void;
         updateName: (id: RepertoireFolderID, newName: string) => void;
         updateLocation: (
@@ -33,7 +36,7 @@ export type RepertoireWithMethods = {
         ) => void;
         delete: (id: RepertoireFolderID) => boolean;
     };
-    lines: RepertoireLines & {
+    lines: {
         create: (line: RepertoireLine, parent: RepertoireFolderID) => void;
         updateLine: (id: UUID, line: RepertoireLine) => void;
         updateLocation: (

--- a/src/types/utility.ts
+++ b/src/types/utility.ts
@@ -3,7 +3,6 @@ import type { Repertoire } from './repertoire';
 
 export type UUID = `${string}-${string}-${string}-${string}-${string}`;
 export type StateSetter<T> = Dispatch<SetStateAction<T>>;
-export type NonEmptyArray<T> = [T, ...T[]];
 
 type FontAwesomeIconName =
     | 'trash'
@@ -28,3 +27,5 @@ export type OutletContext = {
     lineIDsToTrain: UUID[];
     setLineIDsToTrain: StateSetter<UUID[]>;
 };
+
+export type Prettify<T> = { [K in keyof T]: T[K] } & {};

--- a/src/types/zodSchemas.ts
+++ b/src/types/zodSchemas.ts
@@ -55,8 +55,14 @@ const zodFolder = zod.discriminatedUnion('contains', [
         children: zod.tuple([zodUUID], zodUUID),
     }),
 ]);
+const zodBaseFolder = zod.object({
+    name: zod.string(),
+    contains: zod.literal('folders'),
+    children: zod.array(zodUUID),
+});
+
 const zodRepertoireFolders = zod
-    .object({ w: zodFolder, b: zodFolder })
+    .object({ w: zodBaseFolder, b: zodBaseFolder })
     .catchall(zodFolder);
 
 export const StoredRepertoire = zod.object({

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -23,8 +23,8 @@ export const STANDARD_STARTING_FEN =
 
 export const EMPTY_REPERTOIRE: Repertoire = {
     folders: {
-        w: { name: 'White', contains: 'either', children: [] },
-        b: { name: 'Black', contains: 'either', children: [] },
+        w: { name: 'White', contains: 'folders', children: [] },
+        b: { name: 'Black', contains: 'folders', children: [] },
     },
     lines: {},
 };

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -1,5 +1,11 @@
+import type { Colour } from '@/types/chessboard';
 import type { Repertoire } from '@/types/repertoire';
 import type { FontAwesomeIcon } from '@/types/utility';
+
+export const COLOURS = { w: 'white', b: 'black' } as const satisfies Record<
+    Colour,
+    string
+>;
 
 export const ICONS = {
     TICK: 'fa-solid fa-check',


### PR DESCRIPTION
Currently, top-level w/b folders are normal folders, only they cannot be children, nor can they be relocated or deleted.

This allows the following situation:

1. User has empty `w` folder
2. User creates some lines in `w` folder
3. User decides they now want those lines in a subfolder within `w`
4. User is unable to do so because you cannot create a folder inside a lines folder
5. In this case, they must delete every line inside `w` and only when `w` is empty can they create a child folders.

This is not a critical problem with child folders, as sibling/child-of-sibling folders can be created as necessary, then lines relocated as needed (or even the original folder relocated).

Closes #2